### PR TITLE
Compilation Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ ipch
 *.map
 Thumbs.db
 .vs
+Release
+Debug

--- a/samples/AudioPlayer/src/Slider.cpp
+++ b/samples/AudioPlayer/src/Slider.cpp
@@ -38,7 +38,7 @@ bool Slider::isDragging() const
 
 void Slider::setPosition( float v )
 {
-	mPosition = clamp( v, 0.0f, 1.0f );
+	mPosition = math<float>::clamp( v, 0.0f, 1.0f );
 }
 
 void Slider::mouseDown( UiTree* node, MouseEvent& event ) 


### PR DESCRIPTION
vc2013 Community Edition.
Bugfix for error in compilation: identifier 'clamp' not found in Slider.cpp.
